### PR TITLE
Shift lock on shift key long-press

### DIFF
--- a/app/src/main/java/ee/oyatl/ime/make/module/component/KeyboardComponent.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/module/component/KeyboardComponent.kt
@@ -47,27 +47,28 @@ class KeyboardComponent(
     private var ignoreCode: Int = 0
 
     override fun initView(context: Context): View? {
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
         shiftKeyHandler?.reset()
-        shiftKeyHandler?.doubleTapGap = preferences.getFloat("behaviour_double_tap_gap", 500f).toInt()
-        keyboardViewType = preferences.getString("appearance_keyboard_view_type", "canvas") ?: keyboardViewType
+        shiftKeyHandler?.doubleTapGap = pref.getFloat("behaviour_double_tap_gap", 500f).toInt()
+        shiftKeyHandler?.longPressDuration = pref.getFloat("behaviour_long_press_duration", 100f).toInt()
+        keyboardViewType = pref.getString("appearance_keyboard_view_type", "canvas") ?: keyboardViewType
         longPressAction = FlickLongPressAction.of(
-            preferences.getString("behaviour_long_press_action", "shift") ?: "shift"
+            pref.getString("behaviour_long_press_action", "shift") ?: "shift"
         )
         flickUpAction = FlickLongPressAction.of(
-            preferences.getString("behaviour_flick_action_up", "shift") ?: "shift"
+            pref.getString("behaviour_flick_action_up", "shift") ?: "shift"
         )
         flickDownAction = FlickLongPressAction.of(
-            preferences.getString("behaviour_flick_action_down", "symbol") ?: "symbol"
+            pref.getString("behaviour_flick_action_down", "symbol") ?: "symbol"
         )
         flickLeftAction = FlickLongPressAction.of(
-            preferences.getString("behaviour_flick_action_left", "none") ?: "none"
+            pref.getString("behaviour_flick_action_left", "none") ?: "none"
         )
         flickRightAction = FlickLongPressAction.of(
-            preferences.getString("behaviour_flick_action_", "none") ?: "none"
+            pref.getString("behaviour_flick_action_", "none") ?: "none"
         )
 
-        val name = preferences.getString("appearance_theme", "theme_dynamic")
+        val name = pref.getString("appearance_theme", "theme_dynamic")
         val theme = Themes.ofName(name)
         keyboardView = when(keyboardViewType) {
             "stacked_view" -> StackedViewKeyboardView(context, null, keyboard, theme, this, rowHeight, disableTouch)

--- a/app/src/main/java/ee/oyatl/ime/make/module/component/KeyboardComponent.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/module/component/KeyboardComponent.kt
@@ -48,7 +48,6 @@ class KeyboardComponent(
 
     override fun initView(context: Context): View? {
         val pref = PreferenceManager.getDefaultSharedPreferences(context)
-        shiftKeyHandler?.reset()
         shiftKeyHandler?.doubleTapGap = pref.getFloat("behaviour_double_tap_gap", 500f).toInt()
         shiftKeyHandler?.longPressDuration = pref.getFloat("behaviour_long_press_duration", 100f).toInt()
         keyboardViewType = pref.getString("appearance_keyboard_view_type", "canvas") ?: keyboardViewType
@@ -78,9 +77,6 @@ class KeyboardComponent(
     }
 
     override fun reset() {
-        val inputEngine = connectedInputEngine ?: return
-        inputEngine.updateView()
-        inputEngine.onReset()
     }
 
     override fun onItemClicked(candidate: Candidate) {

--- a/app/src/main/java/ee/oyatl/ime/make/module/inputengine/HangulInputEngine.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/module/inputengine/HangulInputEngine.kt
@@ -79,7 +79,7 @@ data class HangulInputEngine(
     }
 
     override fun onReset() {
-        listener.onFinishComposing()
+        super.onReset()
         state = HangulCombiner.State.Initial
     }
 

--- a/app/src/main/java/ee/oyatl/ime/make/module/keyboardview/KeyboardView.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/module/keyboardview/KeyboardView.kt
@@ -117,6 +117,10 @@ abstract class KeyboardView(
             if(this.hapticFeedback && longPressAction != FlickLongPressAction.None) {
                 this.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
             }
+            if(key.key.code == KeyEvent.KEYCODE_SHIFT_LEFT
+                || key.key.code == KeyEvent.KEYCODE_SHIFT_RIGHT) {
+                return@postDelayed
+            }
             listener.onKeyLongClick(key.key.code, key.key.output)
         }, longPressDuration)
 

--- a/app/src/main/java/ee/oyatl/ime/make/service/IMEService.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/service/IMEService.kt
@@ -192,12 +192,14 @@ class IMEService: InputMethodService(), InputEngine.Listener, CandidateListener,
                 true
             }
             KeyEvent.KEYCODE_LANGUAGE_SWITCH -> {
+                resetShiftState()
                 resetCurrentEngine()
                 inputEngineSwitcher?.nextLanguage()
                 reloadView()
                 true
             }
             KeyEvent.KEYCODE_SYM -> {
+                resetShiftState()
                 resetCurrentEngine()
                 inputEngineSwitcher?.nextExtra()
                 reloadView()
@@ -372,6 +374,11 @@ class IMEService: InputMethodService(), InputEngine.Listener, CandidateListener,
         updateTextAroundCursor()
     }
 
+    private fun resetShiftState() {
+        val engine = inputEngineSwitcher?.currentEngine ?: return
+        engine.shiftKeyHandler.reset()
+    }
+
     private fun updateTextAroundCursor() {
         val engine = inputEngineSwitcher?.currentEngine ?: return
         val inputConnection = currentInputConnection ?: return
@@ -425,6 +432,7 @@ class IMEService: InputMethodService(), InputEngine.Listener, CandidateListener,
     }
 
     override fun onLanguageTabClick(index: Int) {
+        inputEngineSwitcher?.currentEngine?.shiftKeyHandler?.reset()
         inputEngineSwitcher?.setLanguage(index)
         reloadView()
     }

--- a/app/src/main/java/ee/oyatl/ime/make/service/IMEService.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/service/IMEService.kt
@@ -134,13 +134,11 @@ class IMEService: InputMethodService(), InputEngine.Listener, CandidateListener,
         onComposingText(newComposingText)
     }
 
-    override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
-        super.onStartInput(attribute, restarting)
+    override fun onStartInputView(editorInfo: EditorInfo?, restarting: Boolean) {
+        super.onStartInputView(editorInfo, restarting)
+        val engine = inputEngineSwitcher?.currentEngine ?: return
+        engine.shiftKeyHandler.reset()
         resetCurrentEngine()
-    }
-
-    override fun onFinishInput() {
-        super.onFinishInput()
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
@@ -371,6 +369,7 @@ class IMEService: InputMethodService(), InputEngine.Listener, CandidateListener,
         val engine = inputEngineSwitcher?.currentEngine ?: return
         engine.onReset()
         engine.onResetComponents()
+        engine.components.forEach { it.updateView() }
         updateTextAroundCursor()
     }
 

--- a/app/src/main/java/ee/oyatl/ime/make/settings/KeyboardLayoutSettingsFragment.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/settings/KeyboardLayoutSettingsFragment.kt
@@ -195,6 +195,7 @@ class KeyboardLayoutSettingsFragment
         frame.addView(engine.initView(context))
         engine.onReset()
         engine.onResetComponents()
+        engine.components.forEach { it.updateView() }
         frame.visibility = VISIBLE
     }
 

--- a/app/src/main/java/ee/oyatl/ime/make/settings/preference/KeyboardComponentsAdapter.kt
+++ b/app/src/main/java/ee/oyatl/ime/make/settings/preference/KeyboardComponentsAdapter.kt
@@ -59,6 +59,7 @@ class KeyboardComponentsAdapter(
             val view = engine.initView(context)
             engine.onReset()
             engine.onResetComponents()
+            engine.components.forEach { it.updateView() }
             if(!previewMode) view?.setOnTouchListener { _, e -> gestureDetector.onTouchEvent(e) }
             binding.componentWrapper.removeAllViews()
             binding.componentWrapper.addView(view)


### PR DESCRIPTION
## Add long-press to shift lock behaviour to shift key
- Double-tap to lock behaviour is preserved
- Multi-touch shift input is also preserved

## Reset shift state automatically
- on input view reset
- on language / symbols mode change